### PR TITLE
Update build and install process

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'omnibus', :git => 'git://github.com/ryandub/omnibus.git', :branch => 'f25ba28521096aaa8c4b7a73febc68ef863b52ea'
-gem 'omnibus-software', :git => 'git://github.com/opscode/omnibus-software.git', :ref => '94b89fe6c4626a4669b1cfbba9ca7af11838989b'
-gem 'test-kitchen', :group => :integration
-gem 'kitchen-vagrant', :group => :integration
-gem 'kitchen-rackspace', :group => :integration
-gem 'berkshelf', :group => :integration
+gem 'omnibus', :git => 'git://github.com/chef/omnibus.git', :branch => 'bd87fe4f6b4d3c82adf67434a34d14c203968f22'
+gem 'omnibus-software', :git => 'git://github.com/opscode/omnibus-software.git', :ref => '5ccf6f7508237bffd7ee8e0288cc00816466312d'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,144 +1,45 @@
 GIT
-  remote: git://github.com/opscode/omnibus-software.git
-  revision: 94b89fe6c4626a4669b1cfbba9ca7af11838989b
-  ref: 94b89fe6c4626a4669b1cfbba9ca7af11838989b
+  remote: git://github.com/chef/omnibus.git
+  revision: bd87fe4f6b4d3c82adf67434a34d14c203968f22
+  branch: bd87fe4f6b4d3c82adf67434a34d14c203968f22
   specs:
-    omnibus-software (4.0.0)
-
-GIT
-  remote: git://github.com/ryandub/omnibus.git
-  revision: f25ba28521096aaa8c4b7a73febc68ef863b52ea
-  branch: f25ba28521096aaa8c4b7a73febc68ef863b52ea
-  specs:
-    omnibus (4.0.0.rc.1)
-      chef-sugar (~> 2.2)
+    omnibus (4.0.0)
+      chef-sugar (~> 3.0)
       cleanroom (~> 1.0)
       mixlib-shellout (~> 1.4)
+      mixlib-versioning
       ohai (~> 7.2)
+      ruby-progressbar (~> 1.7)
       thor (~> 0.18)
       uber-s3
+
+GIT
+  remote: git://github.com/opscode/omnibus-software.git
+  revision: 5ccf6f7508237bffd7ee8e0288cc00816466312d
+  ref: 5ccf6f7508237bffd7ee8e0288cc00816466312d
+  specs:
+    omnibus-software (4.0.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.3.6)
-    berkshelf (3.2.0)
-      addressable (~> 2.3.4)
-      berkshelf-api-client (~> 1.2)
-      buff-config (~> 1.0)
-      buff-extensions (~> 1.0)
-      buff-shell_out (~> 0.1)
-      celluloid (~> 0.16.0)
-      celluloid-io (~> 0.16.1)
-      cleanroom (~> 1.0)
-      faraday (~> 0.9.0)
-      minitar (~> 0.5.4)
-      octokit (~> 3.0)
-      retryable (~> 1.3.3)
-      ridley (~> 4.0)
-      solve (~> 1.1)
-      thor (~> 0.19)
-    berkshelf-api-client (1.2.0)
-      faraday (~> 0.9.0)
-    buff-config (1.0.1)
-      buff-extensions (~> 1.0)
-      varia_model (~> 0.4)
-    buff-extensions (1.0.0)
-    buff-ignore (1.1.1)
-    buff-ruby_engine (0.1.0)
-    buff-shell_out (0.2.0)
-      buff-ruby_engine (~> 0.1.0)
-    builder (3.2.2)
-    celluloid (0.16.0)
-      timers (~> 4.0.0)
-    celluloid-io (0.16.1)
-      celluloid (>= 0.16.0)
-      nio4r (>= 1.0.0)
-    chef-sugar (2.4.1)
+    chef-sugar (3.1.0)
     cleanroom (1.0.0)
-    dep-selector-libgecode (1.0.2)
-    dep_selector (1.0.3)
-      dep-selector-libgecode (~> 1.0)
-      ffi (~> 1.9)
-    erubis (2.7.0)
-    excon (0.41.0)
-    faraday (0.9.0)
-      multipart-post (>= 1.2, < 3)
-    ffi (1.9.6)
-    ffi-yajl (1.2.0)
+    ffi (1.9.8)
+    ffi-yajl (1.4.0)
       ffi (~> 1.5)
-      libyajl2 (~> 1.0)
-    fog (1.24.0)
-      fog-brightbox
-      fog-core (~> 1.23)
-      fog-json
-      fog-radosgw (>= 0.0.2)
-      fog-sakuracloud (>= 0.0.4)
-      fog-softlayer
-      ipaddress (~> 0.5)
-      nokogiri (~> 1.5, >= 1.5.11)
-    fog-brightbox (0.6.1)
-      fog-core (~> 1.22)
-      fog-json
-      inflecto
-    fog-core (1.24.0)
-      builder
-      excon (~> 0.38)
-      formatador (~> 0.2)
-      mime-types
-      net-scp (~> 1.1)
-      net-ssh (>= 2.1.3)
-    fog-json (1.0.0)
-      multi_json (~> 1.0)
-    fog-radosgw (0.0.3)
-      fog-core (>= 1.21.0)
-      fog-json
-      fog-xml (>= 0.0.1)
-    fog-sakuracloud (0.1.1)
-      fog-core
-      fog-json
-    fog-softlayer (0.3.23)
-      fog-core
-      fog-json
-    fog-xml (0.1.1)
-      fog-core
-      nokogiri (~> 1.5, >= 1.5.11)
-    formatador (0.2.5)
-    hashie (2.1.2)
-    hitimes (1.2.2)
-    inflecto (0.0.2)
+      libyajl2 (~> 1.2)
     ipaddress (0.8.0)
-    json (1.8.1)
-    kitchen-rackspace (0.13.0)
-      fog (~> 1.18)
-      test-kitchen (~> 1.1)
-      unf
-    kitchen-vagrant (0.15.0)
-      test-kitchen (~> 1.0)
-    libyajl2 (1.1.0)
+    libyajl2 (1.2.0)
     mime-types (1.25.1)
-    mini_portile (0.6.1)
-    minitar (0.5.4)
-    mixlib-authentication (1.3.0)
-      mixlib-log
     mixlib-cli (1.5.0)
     mixlib-config (2.1.0)
     mixlib-log (1.6.0)
-    mixlib-shellout (1.6.0)
-    multi_json (1.10.1)
-    multipart-post (2.0.0)
-    net-http-persistent (2.9.4)
-    net-scp (1.2.1)
-      net-ssh (>= 2.6.5)
-    net-ssh (2.9.1)
-    nio4r (1.0.1)
-    nokogiri (1.6.4.1)
-      mini_portile (~> 0.6.0)
-    octokit (3.5.2)
-      sawyer (~> 0.5.3)
-    ohai (7.4.0)
+    mixlib-shellout (1.6.1)
+    mixlib-versioning (1.0.0)
+    ohai (7.4.1)
       ffi (~> 1.9)
-      ffi-yajl (~> 1.0)
+      ffi-yajl (~> 1.1)
       ipaddress
       mime-types (~> 1.16)
       mixlib-cli
@@ -147,59 +48,16 @@ GEM
       mixlib-shellout (~> 1.2)
       systemu (~> 2.6.4)
       wmi-lite (~> 1.0)
-    retryable (1.3.6)
-    ridley (4.1.0)
-      addressable
-      buff-config (~> 1.0)
-      buff-extensions (~> 1.0)
-      buff-ignore (~> 1.1)
-      buff-shell_out (~> 0.1)
-      celluloid (~> 0.16.0)
-      celluloid-io (~> 0.16.1)
-      erubis
-      faraday (~> 0.9.0)
-      hashie (>= 2.0.2, < 3.0.0)
-      json (>= 1.7.7)
-      mixlib-authentication (>= 1.3.0)
-      net-http-persistent (>= 2.8)
-      retryable
-      semverse (~> 1.1)
-      varia_model (~> 0.4)
-    safe_yaml (1.0.4)
-    sawyer (0.5.5)
-      addressable (~> 2.3.5)
-      faraday (~> 0.8, < 0.10)
-    semverse (1.2.1)
-    solve (1.2.1)
-      dep_selector (~> 1.0)
-      semverse (~> 1.1)
-    systemu (2.6.4)
-    test-kitchen (1.2.1)
-      mixlib-shellout (~> 1.2)
-      net-scp (~> 1.1)
-      net-ssh (~> 2.7)
-      safe_yaml (~> 1.0)
-      thor (~> 0.18)
+    ruby-progressbar (1.7.5)
+    systemu (2.6.5)
     thor (0.19.1)
-    timers (4.0.1)
-      hitimes
     uber-s3 (0.2.4)
       mime-types (~> 1.17)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.6)
-    varia_model (0.4.0)
-      buff-extensions (~> 1.0)
-      hashie (>= 2.0.2, < 3.0.0)
     wmi-lite (1.0.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  berkshelf
-  kitchen-rackspace
-  kitchen-vagrant
   omnibus!
   omnibus-software!
-  test-kitchen


### PR DESCRIPTION
* Remove unneeded gems from Gemfile and Gemfile.lock to speed up builds.
* Update Omnibus and Omnibus Software to latest versions (#yolo).
* Add extra output in build process.
* Change build process to generate packages and tarballs and associated pointer files.
* Fix checksum generation for tar metadata file.
* Update `install.sh` to add optional flag for tarball install and install_dir:
  * This grabs the tarball pointerfile and initiates the untar functions.
  * tarball is extracted to install_dir specified through `-i /path/to/root/dir`